### PR TITLE
Cap IPC payload size and remove unsafe buffer init

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -62,6 +62,8 @@ pub(crate) enum DiscordSockError {
     IoError(#[from] std::io::Error),
     #[error("failed to convert to u32 from_le_bytes: {0}")]
     TryFromSliceError(#[from] TryFromSliceError),
+    #[error("payload size {size} exceeds maximum allowed size {max}")]
+    PayloadTooLarge { size: usize, max: usize },
     #[error("failed to parse: {0}")]
     ParseError(#[from] InnerParsingError),
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -44,6 +44,9 @@ pub struct Frame {
     pub body: Bytes,
 }
 
+//  Defaults to 16 Mib (just an assumption), this can be changed later
+const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024;
+
 macro_rules! acquire {
     ($s:expr, $x:ident) => {
         let mut $x = $s.lock().await;
@@ -174,8 +177,15 @@ impl DiscordSock {
         let opcode = u32::from_le_bytes(header[0..4].try_into()?);
         let len = u32::from_le_bytes(header[4..8].try_into()?) as usize;
 
+        if len > MAX_FRAME_SIZE {
+            return Err(DiscordSockError::PayloadTooLarge {
+                size: len,
+                max: MAX_FRAME_SIZE,
+            });
+        }
+
         let mut body = BytesMut::with_capacity(len);
-        unsafe { body.set_len(len) };
+        body.resize(len, 0);
         self.read_exact(&mut body).await?;
 
         Ok(Frame {
@@ -190,10 +200,16 @@ impl DiscordSock {
         body: T,
     ) -> Result<(), DiscordSockError> {
         let body = body.as_ref();
+        if body.len() > u32::MAX as usize {
+            return Err(DiscordSockError::PayloadTooLarge {
+                size: body.len(),
+                max: u32::MAX as usize,
+            });
+        }
         let mut buf = BytesMut::with_capacity(8 + body.len());
 
         buf.extend_from_slice(&opcode.to_le_bytes());
-        buf.extend_from_slice(&(body.as_ref().len() as u32).to_le_bytes());
+        buf.extend_from_slice(&(body.len() as u32).to_le_bytes());
         buf.extend_from_slice(body);
 
         self.write(buf.freeze()).await?;


### PR DESCRIPTION

# tl;dr

-  `MAX_FRAME_SIZE` is set 16 MiB to limit the maximum size of incoming frames, i just assumed 16 MiB (can be changed) 
- Added a check in the frame reading logic to return a `PayloadTooLarge` error if an incoming payload exceeds `MAX_FRAME_SIZE`.
- Added a check in the frame writing logic to return a `PayloadTooLarge` error if the outgoing payload exceeds the maximum size representable by a `u32`.